### PR TITLE
Added async support and updated the zerobus data generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,4 +213,7 @@ __marimo__/
 .idea
 */.idea
 
+# generation of binary records for orders
+orders*.bin 
+
 # Buf / protobuf

--- a/zerobus-ingest/README.md
+++ b/zerobus-ingest/README.md
@@ -74,31 +74,93 @@ uv run main.py --env prod   # prod (loads .env-prod)
 
 ### Generate mode
 
-Use `--generate` to create sample order records (Order protobufs) and print them to stdout. The number of records is controlled with `--count` (default: 100).
+Use `--generate` to create sample order records (Order protobufs) and print them to stdout. The number of records is controlled with `--count` (default: 100). With `--validate`, each generated order is checked with protovalidate; only valid orders count toward `--count`, so you always get the requested number of valid orders.
 
 ```bash
 uv run main.py --generate                    # generate 100 orders (default count)
 uv run main.py --generate --count 50         # generate 50 orders
-uv run main.py --generate --count 500        # generate 500 orders
+uv run main.py --generate --validate        # generate 100 orders, skip any that fail validation
+uv run main.py --generate --count 500 --validate
 uv run main.py --env prod --generate --count 200   # prod env, 200 orders
 ```
 
 ### Publish mode
 
-Use `--publish` to generate orders and publish each one to Zerobus (same `--count` and env as generate). Requires `ZEROBUS_*` and `UC_*` env vars.
+Use `--publish` to generate orders and publish each one to Zerobus (same `--count` and env as generate). Requires `ZEROBUS_*` and `UC_*` env vars. By default the sync `ZerobusWriter` is used; add `--async-publish` to use the async writer and record offsets per session. Use `--validate` when generating (without `--orders-file`) so only valid orders are published.
 
 ```bash
-uv run main.py --publish                      # generate and publish 100 orders
+uv run main.py --publish                      # generate and publish 100 orders (sync)
 uv run main.py --publish --count 20           # generate and publish 20 orders
+uv run main.py --publish --validate           # generate 100 valid orders and publish
+uv run main.py --publish --async-publish      # async writer, records offsets per session
+uv run main.py --publish --async-publish --count 50
 uv run main.py --env prod --publish --count 50
 ```
 
-| Option       | Default | Description |
-|-------------|--------|-------------|
-| `--env`     | dev    | Environment: `dev` (loads `.env`) or `prod` (loads `.env-prod`). |
-| `--generate` | off   | Generate sample orders via `datagen.Orders.generate_orders()` and print to stdout. |
-| `--publish` | off    | Generate orders and publish each to Zerobus via `ZerobusWriter`. |
-| `--count`   | 100    | Number of records to generate when `--generate` or `--publish` is set. |
+| Option            | Default | Description |
+|-------------------|--------|-------------|
+| `--env`           | dev    | Environment: `dev` (loads `.env`) or `prod` (loads `.env-prod`). |
+| `--generate`      | off    | Generate sample orders via `datagen.Orders.generate_orders()` and print to stdout. |
+| `--publish`       | off    | Generate orders and publish each to Zerobus via `ZerobusWriter` (sync) or `AsyncZerobusWriter` (if `--async-publish`). |
+| `--async-publish` | off    | Use async writer with `--publish`; records offsets per session and uses default ack callback for progress logging. |
+| `--count`         | 100    | Number of records to generate when `--generate` or `--publish` is set. |
+| `--validate`     | off    | When generating orders, validate each with protovalidate; only valid orders count toward `--count`. Use with `--generate`, `--publish`, or `--generate-orders-file`. |
+| `--generate-orders-file` | —  | Path to write generated orders to a **binary file** (length-delimited protobuf). Use with `--count` (e.g. 10k orders). |
+| `--orders-file`          | —  | Path to a .bin file from `--generate-orders-file`. Load orders from file instead of generating (for reproducible testing with `--publish` or `--generate`). Optional `--count` uses only the first N orders. |
+
+### Generate orders to a binary file
+
+Generate a large batch of orders and store them in a single binary file (length-delimited: each record is varint length + serialized `Order` bytes). No proto change required; read the file back into a `list[Order]` in one call. Useful for benchmarks, replay, or feeding the same dataset to publish multiple times. Use `--validate` to ensure only protovalidate-valid orders are written.
+
+```bash
+uv run main.py --generate-orders-file orders_10k.bin --count 10000
+uv run main.py --generate-orders-file orders_10k.bin --count 10000 --validate   # only valid orders
+```
+
+Then in Python:
+
+```python
+from zerobus_ingest.utils import read_orders_from_binary
+
+orders = read_orders_from_binary("orders_10k.bin")  # list[Order]
+```
+
+To write orders to a file from code (e.g. after custom generation):
+
+```python
+from zerobus_ingest.datagen import Orders
+from zerobus_ingest.utils import write_orders_to_binary
+
+orders = Orders.generate_orders(10_000, seed=42)
+write_orders_to_binary("orders_10k.bin", orders)
+
+# With validation: only valid orders count toward the requested count
+orders = Orders.generate_orders(10_000, seed=42, validate=True)
+write_orders_to_binary("orders_10k.bin", orders)
+```
+
+### Reproducible testing: load orders from a .bin file
+
+Use `--orders-file` to run `--publish` or `--generate` with a fixed dataset from a previously saved .bin file instead of random generation. Same orders every run for non-random testing.
+
+**Example workflow**
+
+1. Create a fixed dataset once (e.g. 10k orders).
+2. Publish from that file (all records, or first N with `--count`).
+3. Optionally print orders from file for inspection.
+
+```bash
+# 1) Create a fixed dataset once
+uv run main.py --generate-orders-file orders_10k.bin --count 10000
+
+# 2) Publish from that file (all 10k, or first N with --count)
+uv run main.py --publish --orders-file orders_10k.bin
+uv run main.py --publish --orders-file orders_10k.bin --count 100
+uv run main.py --publish --async-publish --orders-file orders_10k.bin --count 500
+
+# 3) Or print orders from file (e.g. first 5)
+uv run main.py --generate --orders-file orders_10k.bin --count 5
+```
 
 ---
 
@@ -340,3 +402,99 @@ This matches what the CLI does with `uv run main.py --publish --count 50`.
 | `writer.flush()` | Flush the stream. |
 | `writer.close()` | Close the stream and release resources. Use `with ZerobusWriter.from_config(config) as writer:` to close automatically. |
 | `ZerobusWriter.get_descriptor(record)` | Static: return the record’s `DESCRIPTOR` if it is a protobuf message, else `None`. Useful in tests to assert the descriptor used for `TableProperties` (e.g. `assert ZerobusWriter.get_descriptor(order).full_name == "orders.v1.Order"`). |
+
+---
+
+## AsyncZerobusWriter
+
+`AsyncZerobusWriter` uses the Zerobus async SDK (`zerobus.sdk.aio`) for async ingestion. Use it when you are already in an async context (e.g. FastAPI, aiohttp) or when you want per-record offsets and fire-and-forget options. Default stream options include `record_type=RecordType.PROTO`, `max_inflight_records=5_000`, `recovery=True`, and an optional ack callback for progress logging.
+
+### When to use async vs sync
+
+- **Sync (`ZerobusWriter`)** — Simple scripts, CLI `--publish` without `--async-publish`, or when you prefer blocking `write()` and `ack.wait_for_ack()`.
+- **Async (`AsyncZerobusWriter`)** — Async apps, or when you need `write_offset()` for session offsets, batch/offset methods, or fire-and-forget (`write_nowait` / `write_batch_nowait`). The CLI uses it when you pass `--publish --async-publish`.
+
+### Config
+
+Same config shape as `ZerobusWriter`: use `from_config(config)` (and optionally `ack_callback=...)`). The same env vars and `Config.databricks()` apply.
+
+### ZerobusWriteCallback
+
+`ZerobusWriteCallback` logs progress every N acks and can forward to an inner callback. It is used as the default ack callback when you don't pass one to `AsyncZerobusWriter.from_config()`. You can pass a custom instance or another object that implements `on_ack(offset)`.
+
+```python
+from zerobus_ingest.utils import ZerobusWriteCallback, AsyncZerobusWriter
+
+# Default: log every 100 acks
+callback = ZerobusWriteCallback(log_every_n=100)
+writer = AsyncZerobusWriter.from_config(config, ack_callback=callback)
+
+# With inner callback (e.g. your own AckCallback-like object)
+inner = MyAckHandler()
+callback = ZerobusWriteCallback(inner=inner, log_every_n=50)
+writer = AsyncZerobusWriter.from_config(config, ack_callback=callback)
+```
+
+### Basic usage (async)
+
+Use `async with AsyncZerobusWriter.from_config(config) as writer:` and await `write_offset(record)` to ingest one record and get back the result (offset/ack). Then `await writer.flush()` and the context manager will call `await writer.close()`.
+
+```python
+import asyncio
+from dotenv import load_dotenv
+
+from zerobus_ingest.config import Config
+from zerobus_ingest.datagen import Orders
+from zerobus_ingest.utils import AsyncZerobusWriter
+
+load_dotenv()
+config = Config.databricks()
+orders = Orders.generate_orders(count=50, seed=42)
+
+async def publish():
+    async with AsyncZerobusWriter.from_config(config) as writer:
+        for order in orders:
+            await writer.write_offset(order)  # records offset per record
+        await writer.flush()
+    print(f"Published {len(orders)} orders (async).")
+
+asyncio.run(publish())
+```
+
+This matches what the CLI does with `uv run main.py --publish --async-publish --count 50`.
+
+### Overriding stream options
+
+Use `with_stream_options()` before opening the stream (e.g. before the first write) to override defaults (e.g. `max_inflight_records` or a custom ack callback):
+
+```python
+from zerobus.sdk.shared.definitions import RecordType, StreamConfigurationOptions
+from zerobus_ingest.utils import AsyncZerobusWriter, ZerobusWriteCallback
+
+opts = StreamConfigurationOptions(
+    record_type=RecordType.PROTO,
+    max_inflight_records=10_000,
+    recovery=True,
+    ack_callback=ZerobusWriteCallback(log_every_n=200),
+)
+writer = AsyncZerobusWriter.from_config(config).with_stream_options(opts)
+async with writer as w:
+    for order in orders:
+        await w.write_offset(order)
+    await w.flush()
+```
+
+### API summary (async)
+
+| Method / API | Description |
+|--------------|-------------|
+| `AsyncZerobusWriter.from_config(config, ack_callback=...)` | Build an async writer from a config dict. Optional `ack_callback` (default: `ZerobusWriteCallback()` for progress logging). |
+| `writer.with_stream_options(options)` | Override stream options (e.g. `max_inflight_records`, `ack_callback`). Call before first write. |
+| `await writer.write_offset(record)` | Ingest one record and return the result (offset/ack). Use for recording offsets per session. |
+| `await writer.write_batch_offset(records)` | Ingest a batch and return a list of results (one per record). |
+| `writer.write_nowait(record)` | Fire-and-forget: queue one record without waiting (must be called from an async context with a running loop). |
+| `writer.write_batch_nowait(records)` | Fire-and-forget: queue a batch without waiting. |
+| `await writer.flush()` | Flush the stream and wait for durability. |
+| `await writer.close()` | Close the stream. Use `async with AsyncZerobusWriter.from_config(config) as writer:` to close automatically. |
+| `AsyncZerobusWriter.get_descriptor(record)` | Static: same as `ZerobusWriter.get_descriptor(record)`. |
+| `ZerobusWriteCallback(inner=..., log_every_n=100)` | Ack callback that logs every N acks and optionally forwards to an inner callback. |

--- a/zerobus-ingest/main.py
+++ b/zerobus-ingest/main.py
@@ -18,9 +18,13 @@ if __name__ == "__main__":
         client,
         generate=args.generate,
         publish=args.publish,
+        async_publish=args.async_publish,
         count=args.count,
         config=config if (args.publish or args.create_table) else None,
         create_table=args.create_table,
         descriptor_path=args.descriptor_path,
         message_name=args.message_name,
+        generate_orders_file=args.generate_orders_file,
+        orders_file=args.orders_file,
+        validate=args.validate,
     )

--- a/zerobus-ingest/src/zerobus_ingest/datagen/orders.py
+++ b/zerobus-ingest/src/zerobus_ingest/datagen/orders.py
@@ -101,13 +101,13 @@ class Orders:
         return [order.SerializeToString() for order in orders]
 
     @staticmethod
-    def generate_orders(count: int = 1, seed: int | None = None) -> list[Order]:
+    def generate_orders(count: int = 1, seed: int | None = None, validate: bool = False) -> list[Order]:
         """Generate `count` Order messages using the orders.v1 protobuf classes."""
         if seed is not None:
             random.seed(seed)
         now = int(time.time())
         orders: list[Order] = []
-        for i in range(count):
+        while len(orders) < count:
             order_id = str(uuid.uuid4())
             customer_id = random.choice(Orders._CUSTOMER_IDS)
             num_items = random.randint(1, 4)
@@ -156,10 +156,13 @@ class Orders:
             o.created_at = now
             o.updated_at = now
 
-            try:
-                protovalidate.validate(o)
-            except Exception as e:
-                print(f"Validation: {e}", file=sys.stderr)
-            orders.append(o)
+            if validate:
+                try:
+                    protovalidate.validate(o)
+                    orders.append(o)
+                except Exception as e:
+                    print(f"Validation: {e}", file=sys.stderr)
+            else:
+                orders.append(o)
 
         return orders

--- a/zerobus-ingest/src/zerobus_ingest/main.py
+++ b/zerobus-ingest/src/zerobus_ingest/main.py
@@ -1,6 +1,7 @@
 """CLI and main entry logic for zerobus-ingest."""
 
 import argparse
+import asyncio
 from pathlib import Path
 from typing import Any
 
@@ -10,7 +11,13 @@ from google.protobuf.descriptor_pool import DescriptorPool
 from zerobus.sdk.shared.definitions import RecordType, StreamConfigurationOptions
 
 from zerobus_ingest.datagen import Orders
-from zerobus_ingest.utils import TableUtils, ZerobusWriter
+from zerobus_ingest.utils import (
+    AsyncZerobusWriter,
+    TableUtils,
+    ZerobusWriter,
+    read_orders_from_binary,
+    write_orders_to_binary,
+)
 
 
 def _load_descriptor_from_binary(path: str | Path, message_name: str):
@@ -38,6 +45,25 @@ def _load_descriptor_from_binary(path: str | Path, message_name: str):
     return desc
 
 
+def _get_orders_for_run(
+    orders_file: str | None,
+    count: int,
+    *,
+    seed: int = 42,
+    validate: bool = False,
+) -> list[Any]:
+    """Return orders for --generate or --publish: from .bin file if --orders-file set, else generated."""
+    if orders_file:
+        path = Path(orders_file)
+        if not path.exists():
+            raise FileNotFoundError(f"Orders file not found: {path}")
+        orders = read_orders_from_binary(path)
+        if count < len(orders):
+            orders = orders[:count]
+        return orders
+    return Orders.generate_orders(count, seed=seed, validate=validate)
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -55,6 +81,11 @@ def parse_args():
         "--publish",
         action="store_true",
         help="Generate orders and publish each to Zerobus via ZerobusWriter.",
+    )
+    parser.add_argument(
+        "--async-publish",
+        action="store_true",
+        help="Use async writer (AsyncZerobusWriter) with --publish; records offsets per session.",
     )
     parser.add_argument(
         "--count",
@@ -84,18 +115,54 @@ def parse_args():
         help="Full protobuf message name, e.g. orders.v1.Order (required with "
         + "--create-table).",
     )
+    parser.add_argument(
+        "--generate-orders-file",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Generate orders and write them to a binary file (length-delimited "
+        + "protobuf). Use with --count (e.g. --count 10000).",
+    )
+    parser.add_argument(
+        "--orders-file",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Load orders from a .bin file (from --generate-orders-file) instead of "
+        + "generating. Use with --publish or --generate for reproducible testing. "
+        + "Optional --count limits to first N orders.",
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="When generating orders (--generate, --publish, or --generate-orders-file), "
+        + "validate each order with protovalidate; only count valid orders toward --count.",
+    )
     return parser.parse_args()
+
+
+async def _publish_async(orders: list[Any], config: dict[str, Any]) -> None:
+    """Publish orders via AsyncZerobusWriter using write_offset for session offsets."""
+    async with AsyncZerobusWriter.from_config(config) as writer:
+        for order in orders:
+            await writer.write_offset(order)
+        await writer.flush()
+    print(f"Published {len(orders)} orders to Zerobus (async).")
 
 
 def main(
     workspace_client: WorkspaceClient,
     generate: bool | None = None,
     publish: bool | None = None,
+    async_publish: bool = False,
     count: int = 100,
     config: dict[str, Any] | None = None,
     create_table: bool = False,
     descriptor_path: str | None = None,
     message_name: str | None = None,
+    generate_orders_file: str | None = None,
+    orders_file: str | None = None,
+    validate: bool = False,
 ) -> None:
     # use workspace_client for Databricks API calls
     if create_table:
@@ -118,8 +185,13 @@ def main(
         print(f"Created table {catalog}.{schema}.{table}")
 
     if generate:
-        orders = Orders.generate_orders(count, seed=42)
+        orders = _get_orders_for_run(orders_file, count, validate=validate)
         print(orders)
+
+    if generate_orders_file:
+        orders = Orders.generate_orders(count, seed=42, validate=validate)
+        write_orders_to_binary(generate_orders_file, orders)
+        print(f"Wrote {len(orders)} orders to {generate_orders_file} (binary, length-delimited).")
 
     if publish:
         if not config:
@@ -135,14 +207,16 @@ def main(
                 f"Table {table_name} does not exist in the workspace. "
                 "Create the table before publishing."
             )
-        orders = Orders.generate_orders(count, seed=42)
-        stream_options = StreamConfigurationOptions(record_type=RecordType.PROTO)
-        with ZerobusWriter.from_config(config).with_stream_options(
-            stream_options
-        ) as writer:
-            for order in orders:
-                # we can use wait_for_ack()
-                ack = writer.write(order)
-                ack.wait_for_ack()
-            writer.flush()
-        print(f"Published {len(orders)} orders to Zerobus.")
+        orders = _get_orders_for_run(orders_file, count, validate=validate)
+        if async_publish:
+            asyncio.run(_publish_async(orders, config))
+        else:
+            stream_options = StreamConfigurationOptions(record_type=RecordType.PROTO)
+            with ZerobusWriter.from_config(config).with_stream_options(
+                stream_options
+            ) as writer:
+                for order in orders:
+                    ack = writer.write(order)
+                    ack.wait_for_ack()
+                writer.flush()
+            print(f"Published {len(orders)} orders to Zerobus.")

--- a/zerobus-ingest/src/zerobus_ingest/utils/__init__.py
+++ b/zerobus-ingest/src/zerobus_ingest/utils/__init__.py
@@ -5,7 +5,15 @@ from pathlib import Path
 from zerobus_ingest.utils.protobuf_utils import ProtobufUtils
 from zerobus_ingest.utils.table_utils import TableUtils
 from zerobus_ingest.utils.volume_utils import VolumeUtils
-from zerobus_ingest.utils.writer import ZerobusWriter
+from zerobus_ingest.utils.orders_file import (
+    read_orders_from_binary,
+    write_orders_to_binary,
+)
+from zerobus_ingest.utils.writer import (
+    AsyncZerobusWriter,
+    ZerobusWriteCallback,
+    ZerobusWriter,
+)
 
 
 def read_binary(path: Path | str) -> bytes:
@@ -13,4 +21,14 @@ def read_binary(path: Path | str) -> bytes:
     return Path(path).read_bytes()
 
 
-__all__ = ["read_binary", "ProtobufUtils", "TableUtils", "VolumeUtils", "ZerobusWriter"]
+__all__ = [
+    "AsyncZerobusWriter",
+    "ProtobufUtils",
+    "TableUtils",
+    "VolumeUtils",
+    "ZerobusWriteCallback",
+    "ZerobusWriter",
+    "read_binary",
+    "read_orders_from_binary",
+    "write_orders_to_binary",
+]

--- a/zerobus-ingest/src/zerobus_ingest/utils/orders_file.py
+++ b/zerobus-ingest/src/zerobus_ingest/utils/orders_file.py
@@ -1,0 +1,85 @@
+"""Read/write a list of Order messages to a single binary file (length-delimited format).
+
+Uses the standard protobuf length-delimited encoding: for each message, write
+the length as a varint then the serialized message bytes. No proto change needed;
+one parse per order when reading, one serialize per order when writing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Use same Order type as datagen (avoids circular import from datagen)
+try:
+    from orders.v1 import orders_pb2
+except ImportError:
+    import sys
+    _root = Path(__file__).resolve().parent.parent.parent.parent
+    _gen = _root / "gen" / "python"
+    if str(_gen) not in sys.path:
+        sys.path.insert(0, str(_gen))
+    from orders.v1 import orders_pb2  # noqa: E402
+
+Order = orders_pb2.Order
+
+
+def _encode_varint(value: int) -> bytes:
+    """Encode a non-negative int as a protobuf varint."""
+    parts: list[int] = []
+    while value > 0x7F:
+        parts.append((value & 0x7F) | 0x80)
+        value >>= 7
+    parts.append(value & 0x7F)
+    return bytes(parts)
+
+
+def _decode_varint_from_stream(stream: bytes, pos: int) -> tuple[int, int]:
+    """Decode one varint from stream starting at pos. Returns (value, new_pos)."""
+    result = 0
+    shift = 0
+    while pos < len(stream):
+        b = stream[pos]
+        pos += 1
+        result |= (b & 0x7F) << shift
+        if (b & 0x80) == 0:
+            return result, pos
+        shift += 7
+        if shift >= 35:
+            raise ValueError("Varint too long")
+    raise ValueError("Truncated varint")
+
+
+def write_orders_to_binary(path: Path | str, orders: list[Order]) -> None:
+    """Write a list of Order messages to a binary file (length-delimited).
+
+    Each record is stored as: varint(length) + serialized Order bytes.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as f:
+        for order in orders:
+            data = order.SerializeToString()
+            f.write(_encode_varint(len(data)))
+            f.write(data)
+
+
+def read_orders_from_binary(path: Path | str) -> list[Order]:
+    """Read a list of Order messages from a length-delimited binary file.
+
+    Returns the same list[Order] shape as Orders.generate_orders().
+    """
+    path = Path(path)
+    data = path.read_bytes()
+    orders: list[Order] = []
+    pos = 0
+    while pos < len(data):
+        length, pos = _decode_varint_from_stream(data, pos)
+        if pos + length > len(data):
+            raise ValueError(
+                f"Truncated message at byte {pos}: need {length}, have {len(data) - pos}"
+            )
+        msg = Order()
+        msg.ParseFromString(data[pos : pos + length])
+        orders.append(msg)
+        pos += length
+    return orders

--- a/zerobus-ingest/src/zerobus_ingest/utils/writer.py
+++ b/zerobus-ingest/src/zerobus_ingest/utils/writer.py
@@ -2,15 +2,58 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Any
+from typing import Any, Protocol
 
 from google.protobuf.descriptor import Descriptor
+from zerobus.sdk.aio import ZerobusSdk as AioZerobusSdk, ZerobusStream as AioZerobusStream
 from zerobus.sdk.shared.definitions import (
+    RecordType,
     StreamConfigurationOptions,
     TableProperties,
 )
 from zerobus.sdk.sync import ZerobusSdk, ZerobusStream
+
+
+class AckCallbackLike(Protocol):
+    """Protocol for SDK ack callback (object with on_ack(offset))."""
+
+    def on_ack(self, offset: int) -> None: ...
+
+
+class ZerobusWriteCallback:
+    """
+    Acknowledgment callback that logs progress and optionally forwards to an inner
+    callback. Use with AsyncZerobusWriter for progress logging (e.g. every N acks).
+    """
+
+    def __init__(
+        self,
+        inner: AckCallbackLike | None = None,
+        *,
+        log_every_n: int = 100,
+    ) -> None:
+        self._inner = inner
+        self._log_every_n = log_every_n
+        self._ack_count = 0
+
+    def __call__(self, offset: int) -> None:
+        """Called by the SDK when records are acknowledged (callback is invoked as callable)."""
+        self.on_ack(offset)
+
+    def on_ack(self, offset: int) -> None:
+        """Called when records are acknowledged by the server."""
+        self._ack_count += 1
+        if self._ack_count % self._log_every_n == 0:
+            logging.getLogger(__name__).info(
+                "Acknowledged up to offset: %s (batch #%s)", offset, self._ack_count
+            )
+        if self._inner is not None:
+            if callable(self._inner):
+                self._inner(offset)
+            else:
+                self._inner.on_ack(offset)
 
 
 class ZerobusWriter:
@@ -133,3 +176,167 @@ class ZerobusWriter:
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self.close()
+
+
+def _default_async_stream_options(
+    ack_callback: ZerobusWriteCallback | AckCallbackLike | None,
+) -> StreamConfigurationOptions:
+    """Build default stream options for async writer (PROTO, 5k inflight, recovery)."""
+    callback = ack_callback if ack_callback is not None else ZerobusWriteCallback()
+    return StreamConfigurationOptions(
+        record_type=RecordType.PROTO,
+        max_inflight_records=5_000,
+        recovery=True,
+        ack_callback=callback,
+    )
+
+
+class AsyncZerobusWriter:
+    """
+    Async Zerobus stream writer. Uses zerobus.sdk.aio and supports write_offset,
+    write_batch_offset, write_nowait, write_batch_nowait, flush, and close.
+    """
+
+    def __init__(
+        self,
+        *,
+        host: str,
+        workspace_url: str,
+        workspace_id: str,
+        region: str,
+        client_id: str,
+        client_secret: str,
+        catalog: str,
+        schema: str,
+        table: str,
+        stream_options: StreamConfigurationOptions | None = None,
+        ack_callback: ZerobusWriteCallback | AckCallbackLike | None = None,
+    ) -> None:
+        self._host = host
+        self._workspace_url = workspace_url
+        self._workspace_id = workspace_id
+        self._region = region
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._table_name = f"{catalog}.{schema}.{table}"
+        self._stream_options = stream_options or _default_async_stream_options(
+            ack_callback
+        )
+        self._sdk: AioZerobusSdk | None = None
+        self._stream: AioZerobusStream | None = None
+
+    @classmethod
+    def from_config(
+        cls,
+        config: dict[str, Any],
+        ack_callback: ZerobusWriteCallback | AckCallbackLike | None = None,
+    ) -> AsyncZerobusWriter:
+        """Build an AsyncZerobusWriter from a config dict (e.g. Config.databricks())."""
+        return cls(
+            host=config["host"],
+            workspace_url=config["workspace_url"],
+            workspace_id=config["workspace_id"],
+            region=config["region"],
+            client_id=config["zerobus_client_id"],
+            client_secret=config["zerobus_client_secret"],
+            catalog=config["catalog"],
+            schema=config["schema"],
+            table=config["table"],
+            ack_callback=ack_callback,
+        )
+
+    def with_stream_options(
+        self, options: StreamConfigurationOptions
+    ) -> AsyncZerobusWriter:
+        """
+        Overwrite stream options.
+        Call before any write so they apply when the stream is created.
+        """
+        self._stream_options = options
+        return self
+
+    def _server_endpoint(self) -> str:
+        return (
+            f"{self._workspace_id}.zerobus.{self._region}.cloud.databricks.com"
+        )
+
+    async def _ensure_stream(
+        self, descriptor: Descriptor | None = None
+    ) -> AioZerobusStream:
+        if self._stream is not None:
+            return self._stream
+        if self._sdk is None:
+            server_endpoint = self._server_endpoint()
+            logging.info("Server endpoint: %s", server_endpoint)
+            logging.info("Unity catalog URL: %s", self._workspace_url)
+            self._sdk = AioZerobusSdk(
+                host=server_endpoint,
+                unity_catalog_url=self._workspace_url,
+            )
+        if descriptor is not None:
+            table_properties = TableProperties(
+                self._table_name, descriptor_proto=descriptor
+            )
+        else:
+            table_properties = TableProperties(table_name=self._table_name)
+        self._stream = await self._sdk.create_stream(
+            client_id=self._client_id,
+            client_secret=self._client_secret,
+            table_properties=table_properties,
+            options=self._stream_options,
+        )
+        return self._stream
+
+    @staticmethod
+    def get_descriptor(record: Any) -> Descriptor | None:
+        """Return the DESCRIPTOR for a protobuf message, or None."""
+        return getattr(record, "DESCRIPTOR", None)
+
+    async def write_offset(self, record: Any) -> Any:
+        """
+        Ingest a single record and return the result (offset/ack) when acknowledged.
+        Use for recording offsets for a session.
+        """
+        descriptor = self.get_descriptor(record)
+        stream = await self._ensure_stream(descriptor)
+        return await stream.ingest_record(record)
+
+    async def write_batch_offset(self, records: list[Any]) -> list[Any]:
+        """Ingest a batch of records and return results (one per record) in order."""
+        if not records:
+            return []
+        descriptor = self.get_descriptor(records[0])
+        stream = await self._ensure_stream(descriptor)
+        results = []
+        for record in records:
+            result = await stream.ingest_record(record)
+            results.append(result)
+        return results
+
+    def write_nowait(self, record: Any) -> None:
+        """Fire-and-forget: queue one record without waiting for ack."""
+        asyncio.get_running_loop().create_task(self.write_offset(record))
+
+    def write_batch_nowait(self, records: list[Any]) -> None:
+        """Fire-and-forget: queue a batch without waiting for acks."""
+        for record in records:
+            self.write_nowait(record)
+
+    async def flush(self) -> None:
+        """Flush the stream and wait for durability."""
+        if self._stream is not None:
+            await self._stream.flush()
+
+    async def close(self) -> None:
+        """Close the stream and release resources."""
+        if self._stream is not None:
+            await self._stream.close()
+            self._stream = None
+
+    async def __aenter__(self) -> AsyncZerobusWriter:
+        return self
+
+    async def __aexit__(
+        self, exc_type: Any, exc_val: Any, exc_tb: Any
+    ) -> None:
+        await self.close()

--- a/zerobus-ingest/tests/test_main.py
+++ b/zerobus-ingest/tests/test_main.py
@@ -32,3 +32,60 @@ def test_parse_args_generate_and_count():
         args = parse_args()
     assert args.generate is True
     assert args.count == 50
+
+
+def test_parse_args_async_publish():
+    """--async-publish is parsed and can be combined with --publish."""
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr(sys, "argv", ["main.py", "--publish", "--async-publish"])
+        args = parse_args()
+    assert args.publish is True
+    assert args.async_publish is True
+
+
+def test_parse_args_orders_file():
+    """--orders-file is parsed for loading orders from .bin instead of generating."""
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr(sys, "argv", ["main.py", "--publish", "--orders-file", "orders.bin"])
+        args = parse_args()
+    assert args.orders_file == "orders.bin"
+    assert args.publish is True
+
+
+def test_parse_args_validate():
+    """--validate is parsed and can be combined with --generate or --publish."""
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr(sys, "argv", ["main.py", "--generate", "--validate"])
+        args = parse_args()
+    assert args.validate is True
+    assert args.generate is True
+
+
+def test_get_orders_for_run_from_file(tmp_path):
+    """_get_orders_for_run loads from .bin when orders_file is set and optionally limits by count."""
+    from zerobus_ingest.datagen import Orders
+    from zerobus_ingest.main import _get_orders_for_run
+    from zerobus_ingest.utils import write_orders_to_binary
+
+    path = tmp_path / "orders.bin"
+    orders = Orders.generate_orders(10, seed=99)
+    write_orders_to_binary(path, orders)
+
+    # Load all
+    loaded = _get_orders_for_run(str(path), count=100)
+    assert len(loaded) == 10
+    assert loaded[0].order_id == orders[0].order_id
+
+    # Load first 3 with --count
+    subset = _get_orders_for_run(str(path), count=3)
+    assert len(subset) == 3
+    assert subset[0].order_id == orders[0].order_id
+
+
+def test_get_orders_for_run_generates_when_no_file():
+    """_get_orders_for_run generates orders when orders_file is None."""
+    from zerobus_ingest.main import _get_orders_for_run
+
+    orders = _get_orders_for_run(None, count=5)
+    assert len(orders) == 5
+    assert orders[0].order_id  # has order_id

--- a/zerobus-ingest/tests/test_orders_file.py
+++ b/zerobus-ingest/tests/test_orders_file.py
@@ -1,0 +1,46 @@
+"""Tests for orders_file write/read (length-delimited binary)."""
+
+import tempfile
+from pathlib import Path
+
+from zerobus_ingest.datagen import Orders
+from zerobus_ingest.utils import read_orders_from_binary, write_orders_to_binary
+
+
+def test_write_and_read_orders_roundtrip():
+    """Writing then reading the same orders returns identical list."""
+    orders = Orders.generate_orders(50, seed=123)
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+        path = Path(f.name)
+    try:
+        write_orders_to_binary(path, orders)
+        read_back = read_orders_from_binary(path)
+        assert len(read_back) == 50
+        for a, b in zip(orders, read_back):
+            assert a.order_id == b.order_id
+            assert a.SerializeToString() == b.SerializeToString()
+    finally:
+        path.unlink()
+
+
+def test_read_empty_file_returns_empty_list():
+    """Reading a file with zero length-delimited messages returns []."""
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+        path = Path(f.name)
+        f.write(b"")
+    try:
+        result = read_orders_from_binary(path)
+        assert result == []
+    finally:
+        path.unlink()
+
+
+def test_write_creates_parent_dirs():
+    """write_orders_to_binary creates parent directories if needed."""
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "sub" / "dir" / "orders.bin"
+        orders = Orders.generate_orders(2, seed=1)
+        write_orders_to_binary(path, orders)
+        assert path.exists()
+        read_back = read_orders_from_binary(path)
+        assert len(read_back) == 2

--- a/zerobus-ingest/tests/test_writer.py
+++ b/zerobus-ingest/tests/test_writer.py
@@ -1,12 +1,13 @@
-"""Tests for ZerobusWriter (get_descriptor only; rest requires Databricks)."""
+"""Tests for ZerobusWriter, ZerobusWriteCallback, and AsyncZerobusWriter."""
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from dotenv import load_dotenv
 
 from zerobus_ingest.config import Config
 from zerobus_ingest.datagen import Orders
-from zerobus_ingest.utils import ZerobusWriter
+from zerobus_ingest.utils import AsyncZerobusWriter, ZerobusWriteCallback, ZerobusWriter
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _ENV_FILE = _REPO_ROOT / ".env"
@@ -54,6 +55,107 @@ def test_get_descriptor_from_generated_order():
     assert descriptor is order.DESCRIPTOR
     assert descriptor.name == "Order"
     assert descriptor.full_name == "orders.v1.Order"
+
+
+def test_zerobus_write_callback_increments_count():
+    """ZerobusWriteCallback increments ack count on each on_ack."""
+    cb = ZerobusWriteCallback(log_every_n=100)
+    assert cb._ack_count == 0
+    cb.on_ack(1)
+    assert cb._ack_count == 1
+    cb.on_ack(2)
+    cb.on_ack(3)
+    assert cb._ack_count == 3
+
+
+def test_zerobus_write_callback_forwards_to_inner():
+    """ZerobusWriteCallback forwards on_ack to inner callback when provided."""
+    inner = MagicMock()
+    cb = ZerobusWriteCallback(inner=inner, log_every_n=1000)
+    cb.on_ack(42)
+    inner.on_ack.assert_called_once_with(42)
+
+
+def test_zerobus_write_callback_logs_every_n(caplog):
+    """ZerobusWriteCallback logs progress every log_every_n acks."""
+    import logging
+
+    caplog.set_level(logging.INFO)
+    cb = ZerobusWriteCallback(log_every_n=2)
+    cb.on_ack(1)
+    assert "Acknowledged" not in caplog.text
+    cb.on_ack(2)
+    assert "Acknowledged" in caplog.text and "batch #2" in caplog.text
+
+
+def test_async_zerobus_writer_get_descriptor():
+    """AsyncZerobusWriter.get_descriptor matches ZerobusWriter for Order messages."""
+    orders = Orders.generate_orders(1, seed=42)
+    order = orders[0]
+    assert AsyncZerobusWriter.get_descriptor(order) is not None
+    assert AsyncZerobusWriter.get_descriptor(order) is order.DESCRIPTOR
+    assert AsyncZerobusWriter.get_descriptor({}) is None
+
+
+def test_async_zerobus_writer_from_config():
+    """AsyncZerobusWriter.from_config builds writer with correct table name and options."""
+    config = {
+        "host": "h",
+        "workspace_url": "https://example.databricks.com",
+        "workspace_id": "ws-id",
+        "region": "us-east-1",
+        "zerobus_client_id": "cid",
+        "zerobus_client_secret": "secret",
+        "catalog": "cat",
+        "schema": "sch",
+        "table": "tbl",
+    }
+    writer = AsyncZerobusWriter.from_config(config)
+    assert writer._table_name == "cat.sch.tbl"
+    assert writer._stream_options is not None
+    assert writer._stream is None
+    assert writer._sdk is None
+
+
+def test_async_zerobus_writer_from_config_with_ack_callback():
+    """AsyncZerobusWriter.from_config accepts optional ack_callback."""
+    config = {
+        "host": "h",
+        "workspace_url": "https://example.databricks.com",
+        "workspace_id": "ws-id",
+        "region": "us-east-1",
+        "zerobus_client_id": "cid",
+        "zerobus_client_secret": "secret",
+        "catalog": "cat",
+        "schema": "sch",
+        "table": "tbl",
+    }
+    custom_cb = ZerobusWriteCallback(log_every_n=50)
+    writer = AsyncZerobusWriter.from_config(config, ack_callback=custom_cb)
+    assert writer._stream_options is not None
+    assert writer._stream_options.ack_callback is custom_cb
+
+
+def test_async_zerobus_writer_with_stream_options():
+    """AsyncZerobusWriter.with_stream_options overwrites options and returns self."""
+    from zerobus.sdk.shared.definitions import RecordType, StreamConfigurationOptions
+
+    config = {
+        "host": "h",
+        "workspace_url": "https://example.databricks.com",
+        "workspace_id": "ws-id",
+        "region": "us-east-1",
+        "zerobus_client_id": "cid",
+        "zerobus_client_secret": "secret",
+        "catalog": "cat",
+        "schema": "sch",
+        "table": "tbl",
+    }
+    writer = AsyncZerobusWriter.from_config(config)
+    opts = StreamConfigurationOptions(record_type=RecordType.PROTO, max_inflight_records=100)
+    out = writer.with_stream_options(opts)
+    assert out is writer
+    assert writer._stream_options is opts
 
 
 # @pytest.mark.skipif(


### PR DESCRIPTION
Data generation: is now capable of writing to local disk as a stream of Orders (orders_10k.bin)
- orders can be read from disk as a list[Orders] which is simple since it is a stream of binary protobuf
- and added an optional flag for data validation since it is a slow process in python

Now when testing writing, you can utilize the "sync" apis or the "async" apis. This is a great test bed for using Zerobus.


